### PR TITLE
Fixed: Flags in edit screen

### DIFF
--- a/includes/admin/class-wpm-admin-assets.php
+++ b/includes/admin/class-wpm-admin-assets.php
@@ -201,7 +201,9 @@ class WPM_Admin_Assets {
                 $(window).on('pageshow',function(){
                     if ($('#wpm-language-switcher').length === 0) {
                         var language_switcher = wp.template( 'wpm-ls-customizer' );
-                        $('.edit-post-header-toolbar').prepend(language_switcher);
+						setTimeout(function(){
+							$('.edit-post-header-toolbar').append(language_switcher);
+						}, 200);
                     }
                 });
 


### PR DESCRIPTION
The block editor stopped displaying the language switch in the page/post edit screen.
This fix sets a timeout before showing it, so it works again.
Also appending instead of prepeding for UI consistency.